### PR TITLE
map string literals; additional env bootstrap changes

### DIFF
--- a/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/src/main/java/org/openrewrite/python/PythonParser.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.python;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
+import com.jetbrains.python.psi.PyFile;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.ExecutionContext;
@@ -71,13 +71,13 @@ public class PythonParser implements Parser<P.CompilationUnit> {
         return StreamSupport.stream(sources.spliterator(), false).map(sourceFile -> {
             EncodingDetectingInputStream is = sourceFile.getSource(ctx);
 
-            ASTNode ast = IntelliJUtils.parsePythonSource(sourceFile, ctx);
+            PyFile file = IntelliJUtils.parsePythonSource(sourceFile, ctx);
 
             return new PsiPythonMapper().mapFile(
                     sourceFile.getPath(),
                     is.getCharset().toString(),
                     is.isCharsetBomMarked(),
-                    (ASTWrapperPsiElement) ast.getPsi()
+                    file
             );
         }).collect(toList());
     }

--- a/src/main/java/org/openrewrite/python/internal/PsiPythonMapper.java
+++ b/src/main/java/org/openrewrite/python/internal/PsiPythonMapper.java
@@ -1,6 +1,5 @@
 package org.openrewrite.python.internal;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
@@ -20,7 +19,7 @@ import static org.openrewrite.Tree.randomId;
 
 public class PsiPythonMapper {
 
-    public P.CompilationUnit mapFile(Path path, String charset, boolean isCharsetBomMarked, ASTWrapperPsiElement element) {
+    public P.CompilationUnit mapFile(Path path, String charset, boolean isCharsetBomMarked, PyFile element) {
         new IntelliJUtils.PsiPrinter().print(element.getNode());
         List<Statement> statements = new ArrayList<>();
         for (ASTNode child : element.getNode().getChildren(null)) {
@@ -76,6 +75,8 @@ public class PsiPythonMapper {
             return mapCallExpression((PyCallExpression) element);
         } else if (element instanceof PyNumericLiteralExpression) {
             return mapNumericLiteral((PyNumericLiteralExpression) element);
+        } else if (element instanceof PyStringLiteralExpression) {
+            return mapStringLiteral((PyStringLiteralExpression) element);
         } else if (element instanceof PyTargetExpression) {
             return mapTargetExpression((PyTargetExpression) element);
         }
@@ -135,6 +136,18 @@ public class PsiPythonMapper {
     public P.ExpressionStatement mapExpressionStatement(PyExpressionStatement element) {
         Expression expression = mapExpression(element.getExpression());
         return new P.ExpressionStatement(UUID.randomUUID(), expression);
+    }
+
+    public J.Literal mapStringLiteral(PyStringLiteralExpression element) {
+        return new J.Literal(
+                UUID.randomUUID(),
+                whitespaceBefore(element),
+                Markers.EMPTY,
+                element.getStringValue(),
+                element.getText(),
+                Collections.emptyList(),
+                JavaType.Primitive.String
+        );
     }
 
     public J.Identifier mapTargetExpression(PyTargetExpression element) {

--- a/src/test/java/org/openrewrite/python/tree/ParsingTest.java
+++ b/src/test/java/org/openrewrite/python/tree/ParsingTest.java
@@ -12,6 +12,31 @@ import static org.openrewrite.python.Assertions.python;
 public class ParsingTest implements RewriteTest {
 
     @Test
+    void integerLiteral() {
+        rewriteRun(python("42"));
+    }
+
+    @Test
+    void stringLiteralDoubleQuote() {
+        rewriteRun(python("\"hello world\""));
+    }
+
+    @Test
+    void stringLiteralDoubleQuoteWithEscape() {
+        rewriteRun(python("\"hello \\\"world\\\"\""));
+    }
+
+    @Test
+    void stringLiteralSingleQuote() {
+        rewriteRun(python("'hello world'"));
+    }
+
+    @Test
+    void stringLiteralSingleQuoteWithEscape() {
+        rewriteRun(python("'hello \\'world\\''"));
+    }
+
+    @Test
     void variableDeclNoSpace() {
         rewriteRun(
           python("n=1")


### PR DESCRIPTION
Getting the actual value of string literals required use of `element.getStringValue()`, which goes beyond simple AST traversal and pulls in some additional runtime dependencies.

All tests pass.