### PR TITLE
Support for tree.ParseError instead of ParseError

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
-    id("org.openrewrite.build.recipe-library") version "latest.release"
-    id("org.openrewrite.build.shadow") version "latest.release"
+    id("org.openrewrite.build.recipe-library") version "latest.integration"
+    id("org.openrewrite.build.shadow") version "latest.integration"
+    id("nebula.release") version "17.1.0"
 }
 group = "org.openrewrite"
 description = "Rewrite Python"
@@ -10,12 +11,28 @@ task("printIntellijDependencies", JavaExec::class) {
     classpath = sourceSets["main"].runtimeClasspath
 }
 
-val latest = rewriteRecipe.rewriteVersion.get()
+configurations {
+    all {
+        resolutionStrategy {
+            cacheChangingModulesFor(1, TimeUnit.MINUTES)
+            cacheDynamicVersionsFor(1, TimeUnit.MINUTES)
+            exclude("ch.qos.logback")
+        }
+    }
+}
+
+val latest = if (project.hasProperty("releasing")) {
+    "latest.release"
+} else {
+    "latest.integration"
+}
+
 val lib = fileTree("lib")
 dependencies {
     compileOnly("org.openrewrite:rewrite-test")
 
     implementation(platform("org.openrewrite:rewrite-bom:$latest"))
+    implementation("org.openrewrite:rewrite-core")
     implementation("org.openrewrite:rewrite-java")
     implementation(lib)
 
@@ -35,6 +52,14 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-test")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+}
+
+repositories {
+    mavenLocal()
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+    mavenCentral()
 }
 
 val shadowJar = tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,8 @@ task("printIntellijDependencies", JavaExec::class) {
 configurations {
     all {
         resolutionStrategy {
-            cacheChangingModulesFor(1, TimeUnit.MINUTES)
-            cacheDynamicVersionsFor(1, TimeUnit.MINUTES)
+            cacheChangingModulesFor(1, TimeUnit.HOURS)
+            cacheDynamicVersionsFor(1, TimeUnit.HOURS)
             exclude("ch.qos.logback")
         }
     }

--- a/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/src/main/java/org/openrewrite/python/PythonParser.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.python.internal.PsiPythonMapper;
 import org.openrewrite.python.tree.Py;
 import org.openrewrite.style.NamedStyles;
+import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
@@ -42,7 +43,6 @@ public class PythonParser implements Parser {
     private final List<NamedStyles> styles;
     private final boolean logCompilationWarningsAndErrors;
     private final JavaTypeCache typeCache;
-
     @Override
     public Stream<SourceFile> parse(String... sources) {
         List<Input> inputs = new ArrayList<>(sources.length);


### PR DESCRIPTION

## What's changed?
Updates the API to the latest integration of rewrite

## What's your motivation?
Keeping it up to date

## Anything in particular you'd like reviewers to focus on?
The release process supports the latest integration and the latest release. It needed to change because there is still not a release in rewrite.

## Anyone you would like to review specifically?
@traceyyoshima 

## Have you considered any alternatives or workarounds?
NA

## Any additional context
NA

