### PR TITLE
Adopt guava:32.1.1-jre

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0")
     runtimeOnly("it.unimi.dsi:fastutil:8.5.2")
-    runtimeOnly("com.google.guava:guava:31.1-jre")
+    runtimeOnly("com.google.guava:guava:32.1.1-jre")
     runtimeOnly("one.util:streamex:0.8.1")
 
     implementation("org.ow2.asm:asm:9.5")


### PR DESCRIPTION
## What's changed?
Switch from `guava:31.1-jre` to `guava:32.1.1-jre`.

## What's your motivation?
In response to transitive dependency vulnerability reported on rewrite-maven-plugin.
This is the last reported vulnerability after several other fixes yesterday; having zero reduces the noise.

## Anything in particular you'd like reviewers to focus on?
Was there any particular reason we stuck to the older version?

## Have you considered any alternatives or workarounds?
We could not bump it, and ignore the medium reported vulnerability.

## Any additional context
None provided in the weekly vulnerability report.