### PR TITLE
Adopt guava-jre v32.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0")
     runtimeOnly("it.unimi.dsi:fastutil:8.5.2")
-    runtimeOnly("com.google.guava:guava:31.1-jre")
+    runtimeOnly("com.google.guava:guava:32.1.2-jre")
     runtimeOnly("one.util:streamex:0.8.1")
 
     implementation("org.ow2.asm:asm:9.5")


### PR DESCRIPTION
## What's changed?
Update Guava to https://github.com/google/guava/releases/tag/v32.1.2

## What's your motivation?
https://nvd.nist.gov/vuln/detail/CVE-2023-2976 was reported and suppressed downstream in https://github.com/openrewrite/rewrite-maven-plugin/commit/1600c1414fda030e49a6394d93f65403d3b8eff6.

## Anything in particular you'd like reviewers to focus on?
The release notes seem to indicate the earlier issue has been solved:
> https://github.com/google/guava/issues/6642#issuecomment-1656201382 the section of our Gradle metadata that caused Gradle to report conflicts with listenablefuture. (https://github.com/google/guava/commit/9ed0fa65ab0ecdf2f10d506e7dffeb3595953777)

Would you agree with that assessment?

## Any additional context
A previous attempt to upgrade as reverted in https://github.com/openrewrite/rewrite-python/commit/f487df7dabb8588ae2edb17e31ff7b8ba3ffc133
