### PR TITLE
Call `requirePrintEqualsInput` from `PythonParser#parseInputs`

### DIFF
--- a/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/src/main/java/org/openrewrite/python/PythonParser.java
@@ -69,16 +69,16 @@ public class PythonParser implements Parser {
         ParsingExecutionContextView pctx = ParsingExecutionContextView.view(ctx);
         ParsingEventListener parsingListener = pctx.getParsingListener();
 
-        return acceptedInputs(inputs).map(sourceFile -> {
-            Path path = sourceFile.getRelativePath(relativeTo);
-            try (EncodingDetectingInputStream is = sourceFile.getSource(ctx)) {
+        return acceptedInputs(inputs).map(input -> {
+            Path path = input.getRelativePath(relativeTo);
+            try (EncodingDetectingInputStream is = input.getSource(ctx)) {
                 Py.CompilationUnit py = new PsiPythonMapper(path, is.getCharset(), is.isCharsetBomMarked(), styles, mapLanguageLevel(languageLevel))
                         .mapSource(is.readFully());
-                parsingListener.parsed(sourceFile, py);
-                return py;
+                parsingListener.parsed(input, py);
+                return requirePrintEqualsInput(py, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
-                return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
             }
         });
     }


### PR DESCRIPTION
## What's changed?
Call `requirePrintEqualsInput` from `PythonParser#parseInputs`

## What's your motivation?
Consistency with other parsers, and prevents accidental file modifications.

## Any additional context
Depends on https://github.com/openrewrite/rewrite/pull/3459