### PR TITLE
Recipe StartsWithEndsWith

### DIFF
--- a/src/main/java/org/openrewrite/python/cleanup/StartsWithEndsWith.java
+++ b/src/main/java/org/openrewrite/python/cleanup/StartsWithEndsWith.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.cleanup;
+
+import org.jetbrains.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Repeat;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.python.PythonVisitor;
+import org.openrewrite.python.marker.BuiltinDesugar;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.marker.Markers.EMPTY;
+
+public class StartsWithEndsWith extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Combine startswith and endswith";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`startswith` and `endswith` methods of the `str` object accept a tuple of strings to match against." +
+               "When multiple calls to `startswith` or `endswith` are made on the same string, they can be combined into a single call with a tuple of strings.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Repeat.repeatUntilStable(new StartsWithEndsWithVisitor<>());
+    }
+
+    private static class StartsWithEndsWithVisitor<P> extends PythonVisitor<P> {
+        @Override
+        public J visitBinary(J.Binary binary, P p) {
+            if (binary.getOperator() == J.Binary.Type.Or) {
+                Expression left = binary.getLeft();
+                Expression right = binary.getRight();
+                if (left instanceof J.MethodInvocation && right instanceof J.MethodInvocation) {
+                    J.MethodInvocation leftMethod = (J.MethodInvocation) left;
+                    J.MethodInvocation rightMethod = (J.MethodInvocation) right;
+                    boolean bothStartsWith = leftMethod.getSimpleName().equals("startswith") && rightMethod.getSimpleName().equals("startswith");
+                    boolean bothEndsWith = leftMethod.getSimpleName().equals("endswith") && rightMethod.getSimpleName().equals("endswith");
+                    if ((bothStartsWith || bothEndsWith) &&
+                        leftMethod.getSelect() != null &&
+                        rightMethod.getSelect() != null &&
+                        leftMethod.getArguments().size() == 1 &&
+                        rightMethod.getArguments().size() == 1 &&
+                        leftMethod.getSelect().printTrimmed(getCursor()).equals(rightMethod.getSelect().printTrimmed(getCursor()))
+                    ) {
+                        final List<Expression> rightExpressionFinal = ListUtils.map(
+                                getSimplestRightExpressions(rightMethod),
+                                e -> e.withPrefix(Space.SINGLE_SPACE)
+                        );
+                        if (leftMethod.getArguments().get(0) instanceof J.MethodInvocation &&
+                            "tuple".equals(((J.MethodInvocation) leftMethod.getArguments().get(0)).getSimpleName())) {
+                            J.MethodInvocation tuple = (J.MethodInvocation) leftMethod.getArguments().get(0);
+
+                            tuple = tuple.withArguments(ListUtils.mapFirst(tuple.getArguments(), arg -> {
+                                assert arg instanceof J.NewArray;
+                                J.NewArray newArray = (J.NewArray) arg;
+                                newArray = newArray.withInitializer(ListUtils.concatAll(
+                                        newArray.getInitializer(),
+                                        rightExpressionFinal
+                                ));
+                                return newArray;
+                            }));
+                            return leftMethod.withArguments(singletonList(tuple)).withPrefix(binary.getPrefix());
+                        }
+                        return leftMethod.withArguments(singletonList(
+                                createTuple(
+                                        leftMethod.getArguments().get(0),
+                                        rightExpressionFinal
+                                )
+                        )).withPrefix(binary.getPrefix());
+                    }
+                }
+            }
+            return super.visitBinary(binary, p);
+        }
+
+        @Nullable
+        private static List<Expression> getSimplestRightExpressions(J.MethodInvocation rightMethod) {
+            // The `rightMethod` is already a call to `startsWith` or `endsWith`
+            // If the right side is already a tuple, then unpack the elements
+            if (rightMethod.getArguments().get(0) instanceof J.MethodInvocation &&
+                "tuple".equals(((J.MethodInvocation) rightMethod.getArguments().get(0)).getSimpleName())) {
+                J.NewArray newArray = (J.NewArray) ((J.MethodInvocation) rightMethod.getArguments().get(0)).getArguments().get(0);
+                return newArray.getInitializer();
+            } else {
+                // Otherwise, the right side is a single element
+                return rightMethod.getArguments();
+            }
+        }
+
+        private J.MethodInvocation createTuple(Expression first, List<Expression> right) {
+            Markers markers = Markers.build(singletonList(new BuiltinDesugar(randomId())));
+            J.Identifier builtins = makeBuiltinsIdentifier();
+
+            List<JRightPadded<Expression>> paddedRight =
+                    right
+                            .stream()
+                            .map(JRightPadded::build)
+                            .collect(toList());
+            JContainer<Expression> args = JContainer.build(singletonList(
+                    JRightPadded.build(
+                            new J.NewArray(
+                                    randomId(),
+                                    Space.EMPTY,
+                                    markers,
+                                    null,
+                                    emptyList(),
+                                    JContainer.build(
+                                            ListUtils.concat(
+                                                    JRightPadded.build(first),
+                                                    paddedRight
+                                            )
+                                    ),
+                                    null
+                            )
+                    )
+            ));
+            return new J.MethodInvocation(
+                    randomId(),
+                    Space.EMPTY,
+                    markers,
+                    JRightPadded.build(builtins),
+                    null,
+                    new J.Identifier(randomId(), Space.EMPTY, EMPTY, "tuple", null, null),
+                    args,
+                    null
+            );
+        }
+
+        private J.Identifier makeBuiltinsIdentifier() {
+            return new J.Identifier(randomId(), Space.EMPTY, EMPTY, "__builtins__", null, null);
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/python/cleanup/StartsWithEndsWithTest.java
+++ b/src/test/java/org/openrewrite/python/cleanup/StartsWithEndsWithTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.python.Assertions.python;
+
+@SuppressWarnings({"PyInterpreter", "PyUnresolvedReferences"})
+public class StartsWithEndsWithTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new StartsWithEndsWith());
+    }
+
+    @Test
+    @DocumentExample
+    void startswithAndEndswith() {
+        rewriteRun(
+          python(
+            """
+              a_string = "ababab"
+                                      
+              if a_string.startswith("ab") or a_string.startswith("aba"):
+                  print("Starts with ab")
+                  
+              if a_string.startswith("ab") or a_string.startswith("aba") or a_string.startswith("abab"):
+                  print("Starts with ab")
+                  
+              if a_string.endswith("ab") or a_string.endswith("bab"):
+                  print("Ends with ab")
+              """,
+            """
+              a_string = "ababab"
+                              
+              if a_string.startswith(("ab", "aba")):
+                  print("Starts with ab")
+                  
+              if a_string.startswith(("ab", "aba", "abab")):
+                  print("Starts with ab")
+                            
+              if a_string.endswith(("ab", "bab")):
+                  print("Ends with ab")
+              """
+          )
+        );
+    }
+
+    @Test
+    void morePositiveCases() {
+        rewriteRun(
+          python(
+            """
+              a_string = "ababab"
+                            
+              a_string.startswith("ab") or a_string.startswith("aba") or a_string.startswith("abab") or a_string.startswith("ababa")
+              a_string.startswith("ab") or a_string.startswith(("aba", "abab"))
+              a_string.startswith(("ab", "aba")) or a_string.startswith(("abab", "ababa"))
+              """,
+            """
+              a_string = "ababab"
+                              
+              a_string.startswith(("ab", "aba", "abab", "ababa"))
+              a_string.startswith(("ab", "aba", "abab"))
+              a_string.startswith(("ab", "aba", "abab", "ababa"))
+              """
+          )
+        );
+    }
+
+    @Test
+    void negativeCases() {
+        rewriteRun(
+          python(
+            """
+              a_string = "ababab"
+              b_string = "babab"
+                                      
+              a_string.startswith("ab")
+              a_string.startswith(("ab", "aba"))
+              a_string.startswith("aba") and a_string.startswith("ab")
+              a_string.startswith("aba") and a_string.startswith("ab") or True
+              a_string.startswith("aba") or b_string.startswith("ba")
+              a_string.startswith("aba") or a_string.endswith("bab")
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Python recipe that merges chains of calls of `x.startswith("a") or x.startswtih("ab")`
to a single call of `x.startswith(("a", "ab"))`.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

## What's changed?
<!-- A brief description of the changes in this pull request -->

Adds the first Python cleanup recipe!

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

I wanted to try out writing a python recipe to actually fix a simple issue.

Going to be completely honest, found this quite painful to do.

Without a `PythonTemplate` similar to `JavaTemplate` as well no working `AutoFormat` for python, you have to consider all of the formatting manually.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

Any edge cases that you think I likely missed?


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
