### PR TITLE
Allow passing in an alternate Python executable

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
@@ -188,7 +188,7 @@ public class PythonParser implements Parser {
 
         int port = 54322;
         if (!isServerRunning(port)) {
-            ProcessBuilder processBuilder = new ProcessBuilder("python3", "-m", "rewrite.remote.server", Integer.toString(port));
+            ProcessBuilder processBuilder = new ProcessBuilder(executable, "-m", "rewrite.remote.server", Integer.toString(port));
             if (!pythonPath.isEmpty()) {
                 Map<String, String> environment = processBuilder.environment();
                 environment.compute("PYTHONPATH", (k, current) ->


### PR DESCRIPTION
## What's changed?
Add an `executable` field to `PythonParser` and `PythonParser.Builder`

## What's your motivation?
Some orgs do not use `python3`, but `python` instead for v3.

## Anything in particular you'd like reviewers to focus on?
Any other places were we should make the same change?
Any other name/type you'd like to use instead of `String executable`?

I figured a full `Path` can not always be determined, and might lead to confusion with `verifyRemotingInstallation(Path, Path, Path)`.