### PR TITLE
Fix duplicate lines in multiline comments

### DIFF
--- a/rewrite/rewrite/python/_parser_visitor.py
+++ b/rewrite/rewrite/python/_parser_visitor.py
@@ -15,8 +15,8 @@ from rewrite.java import Space, JRightPadded, JContainer, JLeftPadded, JavaType,
     NameTree, OmitParentheses, Expression, TypeTree, TypedTree, Comment
 from rewrite.java import tree as j
 from . import tree as py
-from .support_types import PyComment
 from .markers import KeywordArguments, KeywordOnlyArguments, Quoted
+from .support_types import PyComment
 
 T = TypeVar('T')
 J2 = TypeVar('J2', bound=J)
@@ -2167,7 +2167,7 @@ class ParserVisitor(ast.NodeVisitor):
                 whitespace.append(char)
             elif char == '#':
                 if comments:
-                    comments[-1] = comments[-1].with_suffix('\n' + ''.join(whitespace))
+                    comments[-1] = comments[-1].with_suffix(''.join(whitespace))
                 else:
                     prefix = ''.join(whitespace)
                 whitespace = []

--- a/rewrite/tests/python/all/comment_test.py
+++ b/rewrite/tests/python/all/comment_test.py
@@ -8,3 +8,61 @@ def test_comment():
 
 def test_windows_line_endings():
     rewrite_run(python("assert 1 # type: foo\r\n"))
+
+
+def test_multiline_comment():
+    # language=python
+    rewrite_run(python("""
+    '''
+    This is a
+    multiline comment
+    '''
+    assert 1
+    """))
+
+
+def test_multiline_comment_with_code():
+    # language=python
+    rewrite_run(python("""
+    # This is a
+    # multiline comment
+    assert 1
+    # This is another
+    # multiline comment
+    """))
+
+
+def test_multiline_comment_in_class():
+    # language=python
+    rewrite_run(python("""
+    class ExampleClass:
+        '''
+        This is a
+        multiline comment
+        inside a class
+        '''
+        def example_method(self):
+            def example_function():
+                '''
+                This is a
+                multiline comment
+                inside a function
+                '''
+                assert 1
+    """))
+
+
+def test_multiline_comment_with_hash():
+    # language=python
+    rewrite_run(python("""
+    class ExampleClass:
+        # This is a
+        # multiline comment
+        # inside a class
+        def example_method(self):
+            def example_function():
+                # This is a
+                # multiline comment
+                # inside a function
+                assert 1
+    """))


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fixed a bug in parsing comments that caused duplicate linebreaks to be added to multiline comments using `#`.

Before the fix, the following test would fail, resulting in an output where an extra `\n` is added after each line starting with `#`

```python
def test_multiline_comment_with_code():
    rewrite_run(python("""
    # This is a
    # multiline comment
    assert 1
    # This is another
    # multiline comment
    """))
```


## Anyone you would like to review specifically?
@knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
