### PR TITLE
Add support for normalizing linebreak on trailing commas

### DIFF
--- a/rewrite/rewrite/python/format/normalize_line_breaks_visitor.py
+++ b/rewrite/rewrite/python/format/normalize_line_breaks_visitor.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar, Union, cast
 
-from rewrite import Tree, P, Cursor, list_map
-from rewrite.java import J, Space, Comment, TextComment
+from rewrite import Tree, P, Cursor, list_map, Marker
+from rewrite.java import J, Space, Comment, TextComment, TrailingComma
 from rewrite.python import PythonVisitor, PySpace, GeneralFormatStyle, PyComment
 from rewrite.visitor import T
 
@@ -42,6 +42,12 @@ class NormalizeLineBreaksVisitor(PythonVisitor):
 
     def visit(self, tree: Optional[Tree], p: P, parent: Optional[Cursor] = None) -> Optional[T]:
         return tree if self._stop else super().visit(tree, p, parent)
+
+    def visit_marker(self, marker: Marker, p: P) -> Marker:
+        m = cast(Marker, super().visit_marker(marker, p))
+        if isinstance(m, TrailingComma):
+            return m.with_suffix(self.visit_space(m.suffix, None, p))
+        return m
 
 
 STR = TypeVar('STR', bound=Optional[str])

--- a/rewrite/tests/python/all/format/normalize_line_breaks_visitor_test.py
+++ b/rewrite/tests/python/all/format/normalize_line_breaks_visitor_test.py
@@ -14,6 +14,10 @@ class TestNormalizeLineBreaksVisitor(unittest.TestCase):
             "    # some comment\r\n"
             "    def test(self):\r\n"
             "        print()\r\n"
+            "        a = [\r\n"
+            "              1,\r\n"
+            "              2,\r\n"
+            "            ]\r\n"
             "\r\n"
         )
         # language=python
@@ -22,6 +26,10 @@ class TestNormalizeLineBreaksVisitor(unittest.TestCase):
             "    # some comment\n"
             "    def test(self):\n"
             "        print()\n"
+            "        a = [\n"
+            "              1,\n"
+            "              2,\n"
+            "            ]\n"
             "\n"
         )
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add support for the autoformatter to normalize linebreaks on code that contains trailing commas.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Was not yet supported.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
