### PR TITLE
Declaring mavenCentral

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,7 @@ allprojects {
     group = "org.openrewrite"
     description = "Rewrite Python"
 }
+
+repositories {
+    mavenCentral()
+}


### PR DESCRIPTION
## What's changed?
Adding the `repositories mavenCentral` declaration in the top-level Gradle file.

## What's your motivation?
In an attempt to address the:
```
Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Cannot resolve external dependency org.projectlombok:lombok:latest.release because no repositories are defined.
Required by:
    root project :
```
issue.
