### PR TITLE
While loop condition spaces

### DIFF
--- a/rewrite/rewrite/python/format/spaces_visitor.py
+++ b/rewrite/rewrite/python/format/spaces_visitor.py
@@ -1,6 +1,7 @@
 from typing import Optional, cast, List, TypeVar
 
 import rewrite.java as j
+from java import WhileLoop
 from rewrite import Tree, list_map
 from rewrite.java import J, Assignment, JLeftPadded, AssignmentOperation, MemberReference, MethodInvocation, \
     MethodDeclaration, Empty, ArrayAccess, Space, If, Block, ClassDeclaration, VariableDeclarations, JRightPadded, \
@@ -299,6 +300,10 @@ class SpacesVisitor(PythonVisitor):
         fl = fl.padding.with_iterable(space_before_left_padded(fl.padding.iterable, True))
         fl = fl.padding.with_iterable(space_before_right_padded_element(fl.padding.iterable, True))
         return fl
+
+    def visit_while_loop(self, while_loop: WhileLoop, p: P) -> J:
+        w = cast(WhileLoop, super().visit_while_loop(while_loop, p))
+        return w.with_condition(space_before(w.condition, True))
 
     def visit_parameterized_type(self, parameterized_type: ParameterizedType, p: P) -> J:
         pt = cast(ParameterizedType, super().visit_parameterized_type(parameterized_type, p))

--- a/rewrite/rewrite/python/format/spaces_visitor.py
+++ b/rewrite/rewrite/python/format/spaces_visitor.py
@@ -1,11 +1,10 @@
 from typing import Optional, cast, List, TypeVar
 
 import rewrite.java as j
-from java import WhileLoop
 from rewrite import Tree, list_map
 from rewrite.java import J, Assignment, JLeftPadded, AssignmentOperation, MemberReference, MethodInvocation, \
     MethodDeclaration, Empty, ArrayAccess, Space, If, Block, ClassDeclaration, VariableDeclarations, JRightPadded, \
-    Import, ParameterizedType, Parentheses
+    Import, ParameterizedType, Parentheses, WhileLoop
 from rewrite.python import PythonVisitor, SpacesStyle, Binary, ChainedAssignment, Slice, CollectionLiteral, \
     ForLoop, DictLiteral, KeyValue, TypeHint, MultiImport, ExpressionTypeTree, ComprehensionExpression
 from rewrite.visitor import P

--- a/rewrite/tests/python/all/format/spaces/loops_space_test.py
+++ b/rewrite/tests/python/all/format/spaces/loops_space_test.py
@@ -19,3 +19,41 @@ def test_spaces_within_array_access_brackets():
         spec=RecipeSpec()
         .with_recipe(from_visitor(SpacesVisitor(style)))
     )
+
+
+def test_spaces_while_loop():
+    style = IntelliJ.spaces()
+    rewrite_run(
+        # language=python
+        python(
+            """\
+            while   x < 10  :
+                print("Hello")
+            """,
+            """\
+            while x < 10:
+                print("Hello")
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(SpacesVisitor(style)))
+    )
+
+
+def test_spaces_while_loop_with_parenthesis():
+    style = IntelliJ.spaces()
+    rewrite_run(
+        # language=python
+        python(
+            """\
+            while(x < 10)  :
+                print("Hello")
+            """,
+            """\
+            while (x < 10):
+                print("Hello")
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(SpacesVisitor(style)))
+    )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds a fix and extra test for while loops to the `SpaceVisitor`, ensuring the while loop conditions have proper spacing.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
