### PR TITLE
Add method parameters alignment, fixes to spaces visitor, and extended end2end tests

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/style/IntelliJ.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/style/IntelliJ.java
@@ -96,7 +96,8 @@ public class IntelliJ extends NamedStyles {
                 4,     // tabSize
                 4,     // indentSize
                 8,     // continuationIndent
-                false  // keepIndentsOnEmptyLines
+                false, // keepIndentsOnEmptyLines
+                new TabsAndIndentsStyle.MethodDeclarationParameters(true)
         );
     }
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/style/TabsAndIndentsStyle.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/style/TabsAndIndentsStyle.java
@@ -29,9 +29,17 @@ public class TabsAndIndentsStyle implements PythonStyle {
     int indentSize;
     int continuationIndent;
     boolean keepIndentsOnEmptyLines;
+    MethodDeclarationParameters methodDeclarationParameters;
+
 
     @Override
     public Style applyDefaults() {
         return StyleHelper.merge(IntelliJ.tabsAndIndents(), this);
+    }
+
+    @Value
+    @With
+    public static class MethodDeclarationParameters {
+        boolean alignMultilineParameters;
     }
 }

--- a/rewrite/pyproject.toml
+++ b/rewrite/pyproject.toml
@@ -44,3 +44,6 @@ check-types = "mypy ./rewrite"
 format = "black ./rewrite ./tests"
 test = "pytest"
 lint = "pylint ./rewrite/**/*.py ./tests/**/*.py"
+
+[tool.pyright]
+reportIncompatibleMethodOverride = false

--- a/rewrite/pyproject.toml
+++ b/rewrite/pyproject.toml
@@ -44,6 +44,3 @@ check-types = "mypy ./rewrite"
 format = "black ./rewrite ./tests"
 test = "pytest"
 lint = "pylint ./rewrite/**/*.py ./tests/**/*.py"
-
-[tool.pyright]
-reportIncompatibleMethodOverride = false

--- a/rewrite/rewrite/python/format/tabs_and_indents_visitor.py
+++ b/rewrite/rewrite/python/format/tabs_and_indents_visitor.py
@@ -137,6 +137,8 @@ class TabsAndIndentsVisitor(PythonVisitor[P]):
 
     @staticmethod
     def compute_first_parameter_offset(method: MethodDeclaration, first_arg: J, cursor: Cursor) -> int:
+        # Clear any annotations to avoid them affecting the offset calculation
+        method = method.with_leading_annotations([])
         class FirstArgPrinter(PrintOutputCapture[TreeVisitor]):
             def append(self, text: Optional[str] = None) -> PrintOutputCapture[P]:
                 if self._context.cursor.value is first_arg:
@@ -149,8 +151,8 @@ class TabsAndIndentsVisitor(PythonVisitor[P]):
             printer.visit(method, capture, cursor.parent_or_throw)
         except RecipeRunException:
             source = capture.get_out()
-            def_idx = source.index("def ")
-            async_idx = source.find("async ")
+            def_idx = source.index("def")
+            async_idx = source.find("async")
             start_idx = async_idx if async_idx != -1 and async_idx < def_idx else def_idx
             return len(source[start_idx:]) + len(first_arg.prefix.last_whitespace)
 

--- a/rewrite/rewrite/python/style.py
+++ b/rewrite/rewrite/python/style.py
@@ -347,6 +347,30 @@ class TabsAndIndentsStyle(PythonStyle):
     def with_keep_indents_on_empty_lines(self, keep_indents_on_empty_lines: bool) -> TabsAndIndentsStyle:
         return self if keep_indents_on_empty_lines is self._keep_indents_on_empty_lines else replace(self, _keep_indents_on_empty_lines=keep_indents_on_empty_lines)
 
+    @dataclass(frozen=True)
+    class MethodDeclarationParameters:
+        _align_multiline_parameters: bool
+
+        @property
+        def align_multiline_parameters(self) -> bool:
+            return self._align_multiline_parameters
+
+        def with_align_multiline_parameters(self,
+                                            align_multiline_parameters: bool) -> TabsAndIndentsStyle.MethodDeclarationParameters:
+            return self if align_multiline_parameters is self._align_multiline_parameters else replace(self,
+                                                                                                       _align_multiline_parameters=align_multiline_parameters)
+
+    _method_declaration_parameters: MethodDeclarationParameters
+
+    @property
+    def method_declaration_parameters(self) -> MethodDeclarationParameters:
+        return self._method_declaration_parameters
+
+    def with_method_declaration_parameters(self,
+                                           method_declaration_parameters: MethodDeclarationParameters) -> TabsAndIndentsStyle:
+        return self if method_declaration_parameters is self._method_declaration_parameters else replace(self,
+                                                                                                         _method_declaration_parameters=method_declaration_parameters)
+
 
 @dataclass(frozen=True)
 class WrappingAndBracesStyle(PythonStyle):
@@ -561,6 +585,9 @@ class IntelliJ(NamedStyles):
             _indent_size=4,
             _continuation_indent=8,
             _keep_indents_on_empty_lines=False,
+            _method_declaration_parameters=TabsAndIndentsStyle.MethodDeclarationParameters(
+                _align_multiline_parameters=True,
+            ),
         )
 
     @classmethod

--- a/rewrite/rewrite/visitor.py
+++ b/rewrite/rewrite/visitor.py
@@ -75,6 +75,12 @@ class Cursor:
                 return c.messages[key]
         return None
 
+    def poll_nearest_message(self, key: str, default_value=None) -> Optional[object]:
+        for c in self.get_path_as_cursors():
+            if c.messages is not None and key in c.messages:
+                return c.messages.pop(key)
+        return default_value
+
     @property
     def parent_or_throw(self) -> Cursor:
         if self.parent is None:

--- a/rewrite/tests/python/all/format/full_formatter_test.py
+++ b/rewrite/tests/python/all/format/full_formatter_test.py
@@ -2,7 +2,7 @@ from rewrite.python import AutoFormat
 from rewrite.test import rewrite_run, python, RecipeSpec
 
 
-def test_remove_leading_module_blank_lines():
+def test_full_formatter():
     rewrite_run(
         # language=python
         python(
@@ -29,15 +29,21 @@ def test_remove_leading_module_blank_lines():
                def method_spaces_test(self,a,    b,c):
                    return a+b*c>>2|4
 
-               def multiline_method (
+               def multiline_method_one(self, very_long_parameter_name: int,
+                       another_long_parameter: str)-> Tuple[int,    str]:
+                   return very_long_parameter_name,     another_long_parameter
+
+               def multiline_method_two(
                self,
                    very_long_parameter_name: int,
                        another_long_parameter: str)-> Tuple[int,str]:
                    return very_long_parameter_name,     another_long_parameter
 
                def list_comprehension_test(self):
+                   a = [x    *2 for x in range(10)    if x>5]
+
                    return [x    *2 for x in range(10)
-                       if x>5]
+                        if x>5]
 
                def dict_comprehension_test(self):
                    keys    =['a','b','c']
@@ -131,13 +137,19 @@ def test_remove_leading_module_blank_lines():
                 def method_spaces_test(self, a, b, c):
                     return a + b * c >> 2 | 4
 
-                def multiline_method(
+                def multiline_method_one(self, very_long_parameter_name: int,
+                                         another_long_parameter: str) -> Tuple[int, str]:
+                    return very_long_parameter_name, another_long_parameter
+
+                def multiline_method_two(
                         self,
                         very_long_parameter_name: int,
                         another_long_parameter: str) -> Tuple[int, str]:
                     return very_long_parameter_name, another_long_parameter
 
                 def list_comprehension_test(self):
+                    a = [x * 2 for x in range(10) if x > 5]
+
                     return [x * 2 for x in range(10)
                             if x > 5]
 

--- a/rewrite/tests/python/all/format/spaces/import_spaces_test.py
+++ b/rewrite/tests/python/all/format/spaces/import_spaces_test.py
@@ -44,7 +44,7 @@ def test_import_multi_import_spaces():
         # language=python
         python(
             """
-            from os import path   ,    system , environ
+            from os import   path   ,    system , environ
             """,
             """
             from os import path, system, environ

--- a/rewrite/tests/python/all/format/spaces/method_declaration_spaces_test.py
+++ b/rewrite/tests/python/all/format/spaces/method_declaration_spaces_test.py
@@ -132,3 +132,27 @@ def test_spaces_after_within_method_declaration_type_hints():
         spec=RecipeSpec()
         .with_recipe(from_visitor(SpacesVisitor(style)))
     )
+
+
+def test_spaces_after_within_method_declaration_return_type():
+    style = IntelliJ.spaces()
+
+    rewrite_run(
+        # language=python
+        python(
+            """
+            def x() -> int:
+                pass
+            def y(a :   int   , b : int = 2) -> int:
+                pass
+            """,
+            """
+            def x() -> int:
+                pass
+            def y(a: int, b: int = 2) -> int:
+                pass
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(SpacesVisitor(style)))
+    )

--- a/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
+++ b/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
@@ -410,6 +410,46 @@ def test_multiline_func_def_with_positional_args():
     )
 
 
+def test_multiline_func_def_with_positional_nested():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+            """
+            class A:
+               def long_function_name_1(
+                 var_one, var_two,
+                        var_three,
+                        var_four):
+                 print(var_one)
+
+               def long_function_name_2(var_one, var_two,
+                        var_three,
+                        var_four):
+                 print(var_one)
+            """,
+            """
+            class A:
+                def long_function_name_1(
+                        var_one, var_two,
+                        var_three,
+                        var_four):
+                    print(var_one)
+
+                def long_function_name_2(var_one, var_two,
+                                         var_three,
+                                         var_four):
+                    print(var_one)
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
+    )
+
+
 def test_multiline_func_def_with_positional_args_after_linebreak():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
     # noinspection PyInconsistentIndentation
@@ -438,7 +478,8 @@ def test_multiline_func_def_with_positional_args_after_linebreak():
     )
 
 
-def test_multiline_func_def_with_positional_args_no_align_multiline():
+@pytest.mark.parametrize("first_line", ["", "\n"])
+def test_multiline_func_def_with_positional_args_no_align_multiline(first_line: str):
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
     style = style.with_method_declaration_parameters(
         style.method_declaration_parameters.with_align_multiline_parameters(False))
@@ -446,13 +487,13 @@ def test_multiline_func_def_with_positional_args_no_align_multiline():
     rewrite_run(
         # language=python
         python(
-            """
+            first_line + """\
             def long_function_name(var_one, var_two,
                     var_three,
                     var_four):
                 print(var_one)
             """,
-            """
+            first_line + """\
             def long_function_name(var_one, var_two,
                     var_three,
                     var_four):
@@ -466,7 +507,8 @@ def test_multiline_func_def_with_positional_args_no_align_multiline():
     )
 
 
-def test_multiline_func_def_with_positional_args_and_no_arg_first_line():
+@pytest.mark.parametrize("first_line", ["", "\n"])
+def test_multiline_func_def_with_positional_args_and_no_arg_first_line(first_line: str):
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
     style = style.with_method_declaration_parameters(
         style.method_declaration_parameters.with_align_multiline_parameters(False))
@@ -474,14 +516,14 @@ def test_multiline_func_def_with_positional_args_and_no_arg_first_line():
     rewrite_run(
         # language=python
         python(
-            """
+            first_line + """\
             def long_function_name(
                 var_one,
                         var_two, var_three,
                     var_four):
                 print(var_one)
             """,
-            """
+            first_line + """\
             def long_function_name(
                     var_one,
                     var_two, var_three,
@@ -496,7 +538,8 @@ def test_multiline_func_def_with_positional_args_and_no_arg_first_line():
     )
 
 
-def test_mm():
+@pytest.mark.parametrize("first_line", ["", "\n"])
+def test_multiline_func_def_with_positional_args_and_extra_space(first_line):
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
     # style = style.with_method_declaration_parameters(
     #     style.method_declaration_parameters.with_align_multiline_parameters(True))
@@ -504,16 +547,16 @@ def test_mm():
     rewrite_run(
         # language=python
         python(
-        """
-        def vax_one(var_one,
-                    var_three,
+            first_line + """\
+        def vax_one(     var_one,
+        var_three,
                  var_four):
             print(var_one)
         """,
-        """
-        def vax_one(var_one,
-                    var_three,
-                    var_four):
+            first_line + """\
+        def vax_one(     var_one,
+                         var_three,
+                         var_four):
             print(var_one)
         """
         ),
@@ -522,7 +565,6 @@ def test_mm():
             from_visitor(TabsAndIndentsVisitor(style))
         )
     )
-
 
 def test_multiline_call_with_args_without_multiline_align():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)

--- a/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
+++ b/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
@@ -942,13 +942,13 @@ def test_method_with_decorator():
         python(
             """
             class A:
-               @property
+               @staticmethod
                def long_function_name(self):
                  return self
             """,
             """
             class A:
-                @property
+                @staticmethod
                 def long_function_name(self):
                     return self
             """

--- a/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
+++ b/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
@@ -464,7 +464,7 @@ def test_multiline_func_def_with_positional_nested_with_async():
                         var_four):
                  print(var_one)
 
-               @dec_with_async_in_name
+               @dec_with_async
                async def long_function_name_2(var_one, var_two,
                         var_three,
                         var_four):
@@ -478,7 +478,7 @@ def test_multiline_func_def_with_positional_nested_with_async():
                         var_four):
                     print(var_one)
 
-                @dec_with_async_in_name
+                @dec_with_async
                 async def long_function_name_2(var_one, var_two,
                                                var_three,
                                                var_four):

--- a/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
+++ b/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
@@ -384,8 +384,64 @@ def test_multiline_list():
     )
 
 
-def test_multiline_call_with_positional_args_no_align_multiline():
+def test_multiline_func_def_with_positional_args():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+            """
+            def long_function_name(var_one, var_two,
+                    var_three,
+                    var_four):
+                print(var_one)
+            """,
+            """
+            def long_function_name(var_one, var_two,
+                                   var_three,
+                                   var_four):
+                print(var_one)
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
+    )
+
+
+def test_multiline_func_def_with_positional_args_after_linebreak():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+            """
+            def long_function_name(
+                var_one,
+                        var_two, var_three,
+                    var_four):
+                print(var_one)
+            """,
+            """
+            def long_function_name(
+                    var_one,
+                    var_two, var_three,
+                    var_four):
+                print(var_one)
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
+    )
+
+
+def test_multiline_func_def_with_positional_args_no_align_multiline():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    style = style.with_method_declaration_parameters(
+        style.method_declaration_parameters.with_align_multiline_parameters(False))
     # noinspection PyInconsistentIndentation
     rewrite_run(
         # language=python
@@ -410,8 +466,10 @@ def test_multiline_call_with_positional_args_no_align_multiline():
     )
 
 
-def test_multiline_call_with_positional_args_and_no_arg_first_line():
+def test_multiline_func_def_with_positional_args_and_no_arg_first_line():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    style = style.with_method_declaration_parameters(
+        style.method_declaration_parameters.with_align_multiline_parameters(False))
     # noinspection PyInconsistentIndentation
     rewrite_run(
         # language=python
@@ -430,6 +488,34 @@ def test_multiline_call_with_positional_args_and_no_arg_first_line():
                     var_four):
                 print(var_one)
             """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
+    )
+
+
+def test_mm():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # style = style.with_method_declaration_parameters(
+    #     style.method_declaration_parameters.with_align_multiline_parameters(True))
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+        """
+        def vax_one(var_one,
+                    var_three,
+                 var_four):
+            print(var_one)
+        """,
+        """
+        def vax_one(var_one,
+                    var_three,
+                    var_four):
+            print(var_one)
+        """
         ),
         spec=RecipeSpec()
         .with_recipes(
@@ -486,6 +572,7 @@ def test_multiline_list_inside_function():
         ),
         spec=RecipeSpec().with_recipes(from_visitor(TabsAndIndentsVisitor(style)))
     )
+
 
 def test_multiline_list_inside_function_with_trailing_comma():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4).with_indent_size(4)

--- a/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
+++ b/rewrite/tests/python/all/format/tabs_and_indents_visitor_test.py
@@ -450,6 +450,48 @@ def test_multiline_func_def_with_positional_nested():
     )
 
 
+def test_multiline_func_def_with_positional_nested_with_async():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+            """
+            class A:
+               async def long_function_name_1(
+                 var_one, var_two,
+                        var_three,
+                        var_four):
+                 print(var_one)
+
+               @dec_with_async_in_name
+               async def long_function_name_2(var_one, var_two,
+                        var_three,
+                        var_four):
+                 print(var_one)
+            """,
+            """
+            class A:
+                async def long_function_name_1(
+                        var_one, var_two,
+                        var_three,
+                        var_four):
+                    print(var_one)
+
+                @dec_with_async_in_name
+                async def long_function_name_2(var_one, var_two,
+                                               var_three,
+                                               var_four):
+                    print(var_one)
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
+    )
+
+
 def test_multiline_func_def_with_positional_args_after_linebreak():
     style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
     # noinspection PyInconsistentIndentation
@@ -889,4 +931,30 @@ def test_method_select_suffix():
                  .startswith("f"))
             """),
         spec=RecipeSpec().with_recipes(from_visitor(TabsAndIndentsVisitor(style)))
+    )
+
+
+def test_method_with_decorator():
+    style = IntelliJ.tabs_and_indents().with_use_tab_character(False).with_tab_size(4)
+    # noinspection PyInconsistentIndentation
+    rewrite_run(
+        # language=python
+        python(
+            """
+            class A:
+               @property
+               def long_function_name(self):
+                 return self
+            """,
+            """
+            class A:
+                @property
+                def long_function_name(self):
+                    return self
+            """
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(TabsAndIndentsVisitor(style))
+        )
     )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds alignment for method parameters and implements several fixes in the visitor of the space, particularly for imports, and extends the overall test-suite.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@knutwannheden 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
