### PR TITLE
Fix spaces around keyvalues in dict comprehensions

### DIFF
--- a/rewrite/rewrite/python/format/spaces_visitor.py
+++ b/rewrite/rewrite/python/format/spaces_visitor.py
@@ -433,11 +433,6 @@ class SpacesVisitor(PythonVisitor):
             else:
                 c = space_after_right_padded(c, self._style.other.before_comma)
                 c = space_before_right_padded_element(c, self._style.other.after_comma)
-            # Handle space before and after colon in key-value pair e.g. {1 :   2} <-> {1: 2}
-            kv = cast(KeyValue, c.element)
-            kv = kv.with_value(space_before(kv.value, self._style.other.after_colon))
-            kv = kv.padding.with_key(space_after_right_padded(kv.padding.key, self._style.other.before_colon))
-            c = c.with_element(kv)
 
             # Handle trailing comma space for last argument e.g. {1: 2, 3: 4, } <-> {1: 2, 3: 4,}
             if idx == arg_size - 1:
@@ -516,6 +511,12 @@ class SpacesVisitor(PythonVisitor):
             ce = ce.with_suffix(update_space(ce.suffix, self._style.within.braces))
 
         return ce
+
+    def visit_key_value(self, key_value: KeyValue, p: P) -> J:
+        # Handle space before and after colon in key-value pair e.g. {1 :   2} <-> {1: 2}
+        kv = cast(KeyValue, super().visit_key_value(key_value, p))
+        kv = kv.with_value(space_before(kv.value, self._style.other.after_colon))
+        return kv.padding.with_key(space_after_right_padded(kv.padding.key, self._style.other.before_colon))
 
     def visit_comprehension_condition(self, condition: ComprehensionExpression.Condition, p: P) -> J:
         cond = cast(ComprehensionExpression.Condition, super().visit_comprehension_condition(condition, p))

--- a/rewrite/tests/python/all/format/spaces/comprehension_spaces_test.py
+++ b/rewrite/tests/python/all/format/spaces/comprehension_spaces_test.py
@@ -105,13 +105,44 @@ def test_spaces_with_dict_comprehension(within_braces):
             """\
             a = {i: i*2 for i   in  range(0, 10)}
             a = {i: i for i   in  [1, 2, 3]}
-            a = {k: v*2 for k,v   in  {   "a": 2, "b": 4}.items( ) }
+            a = {k:   v*2 for k,v   in  {   "a": 2, "b": 4}.items( ) }
             """,
             """\
             a = {i: i * 2 for i in range(0, 10)}
             a = {i: i for i in [1, 2, 3]}
             a = {k: v * 2 for k, v in {"a": 2, "b": 4}.items()}
             """.replace("{", "{" + _s).replace("}", _s + "}")
+        ),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(SpacesVisitor(style)))
+    )
+
+
+def test_spaces_with_dict_comprehension():
+    style = IntelliJ.spaces()
+    rewrite_run(
+        # language=python
+        python(
+            """\
+            a = {k:   1 }
+            a = {k:   1 ** 2}
+            def dict_comprehension_test(self):
+                keys = ['a', 'b', 'c']
+                values = [1, 2, 3]
+                return {k  :     v ** 2
+                        for k, v in zip(keys, values)
+                        }
+            """,
+            """\
+            a = {k: 1}
+            a = {k: 1 ** 2}
+            def dict_comprehension_test(self):
+                keys = ['a', 'b', 'c']
+                values = [1, 2, 3]
+                return {k: v ** 2
+                        for k, v in zip(keys, values)
+                        }
+            """
         ),
         spec=RecipeSpec()
         .with_recipe(from_visitor(SpacesVisitor(style)))


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fix spaces around key value pairs in dict comprehensions

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
