### PR TITLE
Prevent potential Java 21 issues

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonPrinter.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonPrinter.java
@@ -915,7 +915,7 @@ public class PythonPrinter<P> extends PythonVisitor<PrintOutputCapture<P>> {
         @Override
         public J visitCase(J.Case ca, PrintOutputCapture<P> p) {
             beforeSyntax(ca, Location.CASE_PREFIX, p);
-            Expression elem = ca.getCaseLabels().get(0);
+            J elem = ca.getCaseLabels().get(0);
             if (!(elem instanceof J.Identifier) || !((J.Identifier) elem).getSimpleName().equals("default")) {
                 p.append("case");
             }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonPrinter.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonPrinter.java
@@ -915,11 +915,11 @@ public class PythonPrinter<P> extends PythonVisitor<PrintOutputCapture<P>> {
         @Override
         public J visitCase(J.Case ca, PrintOutputCapture<P> p) {
             beforeSyntax(ca, Location.CASE_PREFIX, p);
-            Expression elem = ca.getExpressions().get(0);
+            Expression elem = ca.getCaseLabels().get(0);
             if (!(elem instanceof J.Identifier) || !((J.Identifier) elem).getSimpleName().equals("default")) {
                 p.append("case");
             }
-            visitContainer("", ca.getPadding().getExpressions(), JContainer.Location.CASE_EXPRESSION, ",", "", p);
+            visitContainer("", ca.getPadding().getCaseLabels(), JContainer.Location.CASE_EXPRESSION, ",", "", p);
             visitSpace(ca.getPadding().getStatements().getBefore(), Location.CASE, p);
             visitStatements(ca.getPadding().getStatements().getPadding().getElements(), JRightPadded.Location.CASE, p);
             if (ca.getBody() instanceof Statement) {


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Apply newest `getCaseLabel` instead of `getExpression`

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
