### PR TITLE
`PythonTemplate` support

### DIFF
--- a/rewrite/rewrite/java/__init__.py
+++ b/rewrite/rewrite/java/__init__.py
@@ -91,5 +91,9 @@ __all__ = [
     'WhileLoop',
     'Wildcard',
     'Yield',
-    'Unknown'
+    'Unknown',
+
+    # Templating
+    'CoordinateBuilder',
+    'JavaCoordinates',
 ]

--- a/rewrite/rewrite/java/support_types.py
+++ b/rewrite/rewrite/java/support_types.py
@@ -319,16 +319,63 @@ Space.EMPTY = Space([], '')
 Space.SINGLE_SPACE = Space([], ' ')
 
 
+@dataclass
+class CoordinateBuilder:
+    tree: J
+
+    def before(self, loc: Space.Location) -> JavaCoordinates:
+        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.BEFORE)
+
+    def after(self, loc: Space.Location) -> JavaCoordinates:
+        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.AFTER)
+
+    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
+        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.REPLACE)
+
+
+@dataclass
+class _ExpressionCoordinateBuilder(CoordinateBuilder):
+    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
+        return JavaCoordinates(self.tree, loc or Space.Location.EXPRESSION_PREFIX, JavaCoordinates.Mode.REPLACE)
+
+
+@dataclass
+class _StatementCoordinateBuilder(CoordinateBuilder):
+    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
+        return JavaCoordinates(self.tree, loc or Space.Location.STATEMENT_PREFIX, JavaCoordinates.Mode.REPLACE)
+
+
+CoordinateBuilder.Expression = _ExpressionCoordinateBuilder  # type: ignore
+CoordinateBuilder.Statement = _StatementCoordinateBuilder  # type: ignore
+
+
+@dataclass
+class JavaCoordinates:
+    tree: J
+    loc: Space.Location
+    mode: Mode
+
+    def is_replacement(self) -> bool:
+        return self.mode == JavaCoordinates.Mode.REPLACE
+
+    class Mode(Enum):
+        AFTER = 0,
+        BEFORE = 1,
+        REPLACE = 2,
+
+
 class JavaSourceFile(J, SourceFile):
     pass
 
 
 class Expression(J):
-    pass
+    def get_coordinates(self) -> CoordinateBuilder.Expression:  # type: ignore
+        return CoordinateBuilder.Expression(self)  # type: ignore
 
 
 class Statement(J):
-    pass
+    def get_coordinates(self) -> CoordinateBuilder.Statement:  # type: ignore
+        return CoordinateBuilder.Statement(self)  # type: ignore
 
 
 class TypedTree(J):

--- a/rewrite/rewrite/python/__init__.py
+++ b/rewrite/rewrite/python/__init__.py
@@ -6,6 +6,7 @@ from .visitor import *
 from .markers import *
 from .style import *
 from .format import *
+from .templating import *
 
 __all__ = [
     'Py',
@@ -72,4 +73,7 @@ __all__ = [
     'NormalizeFormatVisitor',
     'NormalizeTabsOrSpacesVisitor',
     'SpacesVisitor',
+
+    # Templating
+    'PythonTemplate',
 ]

--- a/rewrite/rewrite/python/templating.py
+++ b/rewrite/rewrite/python/templating.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from .parser import PythonParserBuilder
+from ..parser import ParserBuilder
+from ..visitor import Cursor
+
+
+@dataclass
+class PythonTemplate:
+    code: str
+    on_after_variable_substitution: Optional[Callable[[str], None]] = None
+    _template_parser: PythonTemplateParser = field(init=False, repr=False)
+
+    def __init__(self, code: str, parser_builder: PythonParserBuilder,
+                 on_after_variable_substitution: Optional[Callable[[str], None]] = None):
+        self.code = code
+        self.on_after_variable_substitution = on_after_variable_substitution
+        self._template_parser = PythonTemplateParser(False, parser_builder, self.on_after_variable_substitution)
+
+    def apply(self, scope: Cursor):
+        pass
+
+
+@dataclass
+class PythonTemplateParser:
+    context_sensitive: bool
+    parser_builder: ParserBuilder
+    on_after_variable_substitution: Optional[Callable[[str], None]] = None


### PR DESCRIPTION
The `PythonTemplate` will be the Python counterpart to Java's `JavaTemplate` to allow parsing strings into LSTs and then embedding them into a "host" LST model.
