### PR TITLE
Assign response from `pattern.withChildren`

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
@@ -303,7 +303,7 @@ public class PythonVisitor<P> extends JavaVisitor<P> {
         } else {
             pattern = (Py.MatchCase.Pattern) temp;
         }
-        pattern.withChildren(ListUtils.map(
+        pattern = pattern.withChildren(ListUtils.map(
                 pattern.getChildren(),
                 child -> (Expression) visitAndCast(child, p)
         ));


### PR DESCRIPTION
As discovered with a recipe, the response from this wither was ignored.